### PR TITLE
[WIP] Add sensor info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ hidapi = "^0.7.99"
 pynput = "^1.7.1"
 pyside2 = "^5.14"
 Xlib = "^0.21"
+psutil = "^5.8.0"
 
 [tool.poetry.dev-dependencies]
 vulture = "^1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,13 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
-streamdeck = "^0.8.2"
+python = ">=3.8,<3.10"
+streamdeck = "^0.8.3"
 pillow = "^7.0.0"
 hidapi = "^0.7.99"
 pynput = "^1.7.1"
-pyside2 = "^5.13"
+pyside2 = "^5.14"
+Xlib = "^0.21"
 
 [tool.poetry.dev-dependencies]
 vulture = "^1.0"

--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -1,5 +1,6 @@
 """Defines the Python API for interacting with the StreamDeck Configuration UI"""
 import json
+import psutil
 import sys
 import os
 from pathlib import Path
@@ -485,6 +486,32 @@ def _render_key_image(deck, icon: str = "", text: str = "", information: str = "
         draw.text(label_pos, text=text, font=true_font, fill="white")
 
     return ImageHelpers.PILHelper.to_native_format(deck, image)
+
+
+def get_sensors_list():
+    _l = []
+    for sensor, sub_sensors in psutil.sensors_temperatures().items():
+        # Small issue when having multiple NVME drives, ignoring them for the moment
+        if not sensor == "nvme":
+            for elem in sub_sensors:
+                _l.append("Sensor:" + str(sensor) + ":" + elem.label)
+    return _l
+
+
+def _get_sensor(sensor_list: list, index: int):
+    sp_key = sensor_list[index].split(":")
+    if sp_key[0] == "Sensor":
+        sensor = psutil.sensors_temperatures()[sp_key[1]]
+        for i in sensor:
+            if i.label == sp_key[2]:
+                return str(i.current)
+    return ""
+
+
+def set_button_sensor(deck_id: str, page: int, button: int, start: bool, sensor_list: list, index: int) -> None:
+    """Set the button to display live time every second"""
+    _button_state(deck_id, page, button)["font_size"] = 28
+    _set_button_live_info(deck_id, page, button, start, _get_sensor, [sensor_list, index])
 
 
 if os.path.isfile(STATE_FILE):

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -132,7 +132,8 @@ def set_information(ui, index: int, button=None, build: bool=False) -> None:
         # Current Time (M)
         api.set_button_live_minute(deck_id, _page(ui), button.index, True)
     else:
-        api.set_button_live_time(deck_id, _page(ui), button.index, False)
+        # We consider it's a sensor
+        api.set_button_sensor(deck_id, _page(ui), button.index, True, [ui.information.itemText(i) for i in range(ui.information.count())], index)
 
     ui.text.setText(api.get_button_text(deck_id, _page(ui), button.index))
 
@@ -306,6 +307,8 @@ def start(_exit: bool = False) -> None:
     menu.addAction(action_exit)
 
     tray.setContextMenu(menu)
+
+    ui.information.addItems(api.get_sensors_list())
 
     ui.text.textChanged.connect(partial(queue_text_change, ui))
     ui.command.textChanged.connect(partial(update_button_command, ui))


### PR DESCRIPTION
Adding the possibility to display sensors info on buttons.

For now, it ignores NVME drives because psutil doesn't gives the NVMe drive ID to differentiate each NVMe drive (I have 2 on my PC). Maybe I should use smartctl, but it needs root, so nope. I may find something, but I don't want to parse lm-sensors output.
Maybe going through sysfs would help, but I want to avoid adding too much code.

Still a WIP, but if you have any advice, comment, don't hesitate ;)